### PR TITLE
Fix NPM missing during build

### DIFF
--- a/org.signal.Signal.yml
+++ b/org.signal.Signal.yml
@@ -2,6 +2,8 @@ app-id: org.signal.Signal
 runtime: org.freedesktop.Platform
 runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.node20
 command: signal-desktop
 finish-args:
   - --device=dri
@@ -10,6 +12,8 @@ finish-args:
   - --share=network
   - --socket=wayland
   - --socket=x11
+build-options:
+  append-path: /usr/lib/sdk/node20/bin
 modules:
   - name: signal-desktop
     buildsystem: simple


### PR DESCRIPTION
## Summary
- add Node 20 SDK extension to manifest
- ensure npm is found by extending PATH

## Testing
- `yarn install` *(fails: Bad response 403)*

------
https://chatgpt.com/codex/tasks/task_e_684d348b293c8325bafee00fcda11b6b